### PR TITLE
add init() to public struct

### DIFF
--- a/OrdermentumSDK/Models/AddOns.swift
+++ b/OrdermentumSDK/Models/AddOns.swift
@@ -13,6 +13,8 @@ public struct AddOnsResponse {
 }
 
 public struct AddOn {
+    public init() {}
+    
     public var connectUrl: String = ""
     public var disconnectUrl: String = ""
     public var entityName: String = ""


### PR DESCRIPTION
Might resolve:
'AddOn' initializer is inaccessible due to 'internal' protection level