### PR TITLE
bugfix/RETAILER-3210 / Classic standing orders crash

### DIFF
--- a/Sources/OrdermentumSDK/Models/Order.swift
+++ b/Sources/OrdermentumSDK/Models/Order.swift
@@ -518,7 +518,7 @@ extension ClassicStandingOrderRecurrenceInfo: Decodable {
         freq = try container.decodeIfPresent(String.self, forKey: .freq) ?? ""
         byhour = try container.decodeIfPresent(String.self, forKey: .byhour) ?? ""
         byminute = try container.decodeIfPresent(String.self, forKey: .byminute) ?? ""
-        interval = try container.decodeIfPresent(String.self, forKey: .interval) ?? ""
+        interval = try container.safeStringIntDecode(forKey: .interval) ?? ""
         timezone = try container.decodeIfPresent(String.self, forKey: .timezone) ?? ""
     }
 }


### PR DESCRIPTION
#### Description

https://ordermentum.atlassian.net/browse/RETAILER-3210

Crash report: https://console.firebase.google.com/project/ordermentum-5c583/crashlytics/app/ios:com.ordermentum.Ordermentum/issues/08d8d9067fd9b182399f6d248afb7da6?time=last-seven-days&sessionEventKey=8c98a73af0ae4fdab5ee272109da52f8_1565256628983980621

Fix crash on orders tab for classic standing orders

----
#### PR Type

_Check one or more and add the corresponding number of reviewers_

- [x] Bugfix _(1)_
- [ ] Minor change _(1)_
- [ ] Refactor (no functional changes/no api changes) _(1)_
- [ ] Feature _(2)_
- [ ] Backwards compatible change in functionality _(2)_
- [ ] Breaking change (existing functionality no longer works as expected) _(2)_
- [ ] Critical impact (security, payments or critical functionality) _(2+CTO)_

----
#### Changes

Safe decode for interval property, was Int when checking the response

| Original | Updated |
| --- | --- |
| https://user-images.githubusercontent.com/49466085/126409624-f86b98f7-bc50-4cbb-9736-a62564b716ac.mov | https://user-images.githubusercontent.com/49466085/126409628-1f6ceffd-76c1-4bc3-9166-26a340ae3261.mov |

----

#### Acceptance Criteria

Steps to replicate here: https://ordermentum.atlassian.net/browse/RETAILER-3210

----

#### Checklist:

- [ ] Tests – Have you added or edited the test cases?
- [ ] Context – Have you tested this with a non-admin user?
- [ ] Rebase – Has this PR been rebased against `develop`?
- [ ] Feature Flag - If this is a new feature, does it have a feature flag?
- [ ] Release - Can this be released to production once tested?
